### PR TITLE
Prevents outlines on focused input fields

### DIFF
--- a/pixelflix-app/src/Components/Login/Login.scss
+++ b/pixelflix-app/src/Components/Login/Login.scss
@@ -66,6 +66,10 @@
       padding: 1em;
     }
 
+    &-input:focus {
+      outline: none;
+    }
+
     & button {
       border: none;
       border-radius: 6px;

--- a/pixelflix-app/src/Components/Signup/Signup.scss
+++ b/pixelflix-app/src/Components/Signup/Signup.scss
@@ -67,6 +67,10 @@
       padding: 1em;
     }
 
+    &-input:focus {
+      outline: none;
+    }
+
     & button {
       border: none;
       border-radius: 6px;


### PR DESCRIPTION
Updated the CSS on Signup and Login pages so that when the input fields in the form are in focus, there are no outlines.